### PR TITLE
Stop rounding colours

### DIFF
--- a/convertcolor.lua
+++ b/convertcolor.lua
@@ -3,7 +3,6 @@ local M = {}
 local function hex (hex, alpha) 
 	local redColor,greenColor,blueColor=hex:match('#?(..)(..)(..)')
 	redColor, greenColor, blueColor = tonumber(redColor, 16)/255, tonumber(greenColor, 16)/255, tonumber(blueColor, 16)/255
-	redColor, greenColor, blueColor = math.floor(redColor*100)/100, math.floor(greenColor*100)/100, math.floor(blueColor*100)/100
 	if alpha == nil then
 		return redColor, greenColor, blueColor
 	end
@@ -12,13 +11,11 @@ end
 
 local function rgb (r, g, b)
 	local redColor,greenColor,blueColor=r/255, g/255, b/255
-	redColor, greenColor, blueColor = math.floor(redColor*100)/100, math.floor(greenColor*100)/100, math.floor(blueColor*100)/100
 	return redColor, greenColor, blueColor
 end
 
 local function rgba (r, g, b, alpha)
 	local redColor,greenColor,blueColor=r/255, g/255, b/255
-	redColor, greenColor, blueColor = math.floor(redColor*100)/100, math.floor(greenColor*100)/100, math.floor(blueColor*100)/100
 	return redColor, greenColor, blueColor, alpha
 end
 


### PR DESCRIPTION
Rounding the colours is inaccurate and returning a colour that is noticeably different.

For example the colour `#1c1c1c` is being round to `#191919` and can be seen clearly below.

![image](https://github.com/andrewyavors/Lua-Color-Converter/assets/42767280/74d57c23-8d58-4bae-90d5-4b6f6c7442b4)